### PR TITLE
Add connection field to Connection (api not conforming to spec)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    budgea_client (4.1.0)
+    budgea_client (5.0.0)
       json (~> 2.1, >= 2.1.0)
       typhoeus (~> 1.0, >= 1.0.1)
 

--- a/budgea_openapi.json
+++ b/budgea_openapi.json
@@ -24123,6 +24123,9 @@
         },
         "connection": {
           "$ref": "#/definitions/Connection"
+        },
+        "message": {
+          "type": "string"
         }
       },
       "example": {

--- a/budgea_openapi.json
+++ b/budgea_openapi.json
@@ -24120,6 +24120,9 @@
           "items": {
             "$ref": "#/definitions/Subscription"
           }
+        },
+        "connection": {
+          "$ref": "#/definitions/Connection"
         }
       },
       "example": {

--- a/docs/Connection.md
+++ b/docs/Connection.md
@@ -16,5 +16,6 @@ Name | Type | Description | Notes
 **next_try** | **DateTime** | Date of next synchronization | [optional] 
 **accounts** | [**Array&lt;Account&gt;**](Account.md) |  | [optional] 
 **subscriptions** | [**Array&lt;Subscription&gt;**](Subscription.md) |  | [optional] 
+**connection** | [**Connection**](Connection.md) |  | [optional] 
 
 

--- a/lib/budgea_client/models/connection.rb
+++ b/lib/budgea_client/models/connection.rb
@@ -51,6 +51,8 @@ module BudgeaClient
 
     attr_accessor :subscriptions
 
+    attr_accessor :connection
+
     # Attribute mapping from ruby-style variable name to JSON key.
     def self.attribute_map
       {
@@ -66,7 +68,8 @@ module BudgeaClient
         :'last_push' => :'last_push',
         :'next_try' => :'next_try',
         :'accounts' => :'accounts',
-        :'subscriptions' => :'subscriptions'
+        :'subscriptions' => :'subscriptions',
+        :'connection' => :'connection'
       }
     end
 
@@ -85,7 +88,8 @@ module BudgeaClient
         :'last_push' => :'DateTime',
         :'next_try' => :'DateTime',
         :'accounts' => :'Array<Account>',
-        :'subscriptions' => :'Array<Subscription>'
+        :'subscriptions' => :'Array<Subscription>',
+        :'connection' => :'Connection'
       }
     end
 
@@ -154,6 +158,10 @@ module BudgeaClient
           self.subscriptions = value
         end
       end
+
+      if attributes.has_key?(:'connection')
+        self.connection = attributes[:'connection']
+      end
     end
 
     # Show invalid properties with the reasons. Usually used together with valid?
@@ -201,7 +209,8 @@ module BudgeaClient
           last_push == o.last_push &&
           next_try == o.next_try &&
           accounts == o.accounts &&
-          subscriptions == o.subscriptions
+          subscriptions == o.subscriptions &&
+          connection == o.connection
     end
 
     # @see the `==` method
@@ -213,7 +222,7 @@ module BudgeaClient
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [id, id_user, id_connector, last_update, created, error, error_message, expire, active, last_push, next_try, accounts, subscriptions].hash
+      [id, id_user, id_connector, last_update, created, error, error_message, expire, active, last_push, next_try, accounts, subscriptions, connection].hash
     end
 
     # Builds the object from hash

--- a/lib/budgea_client/version.rb
+++ b/lib/budgea_client/version.rb
@@ -11,5 +11,5 @@ Swagger Codegen version: 2.4.1
 =end
 
 module BudgeaClient
-  VERSION = '4.1.0'
+  VERSION = '5.0.0'
 end


### PR DESCRIPTION
issue 15740

BI returns {...} or {connection: ...} for routes returning connections with the **same http code** 200 with the **same url** and the **same querystring**. Why? 'cause it's ok for them to have the implementation be inconsistent with the spec 🤷🏻‍♀️